### PR TITLE
Fix overlap = 0 in some cases

### DIFF
--- a/collision/util.py
+++ b/collision/util.py
@@ -199,7 +199,7 @@ def is_separating_axis(a_pos, b_pos, a_points, b_points, axis, response=None):
                 overlap = option_1 if option_1 < option_2 else option_2
 
         abs_overlap = abs(overlap)
-        if abs_overlap < response.overlap:
+        if abs_overlap > 0 and abs_overlap < response.overlap:
             response.overlap = abs_overlap
             response.overlap_n.set(axis)
             if overlap < 0:


### PR DESCRIPTION
I was running into some bugs with response.overlap being equal to 0 in some cases which also messes up overlap_v. After running some tests, it turns out that overlap can sometimes be equal to 0 which is due to the fact we're testing against all normals. Which causes a problem if you're replacing response.overlap with the lowest value. Checking if abs_overlap is greater than 0 (line 202) fixed this for me completely.